### PR TITLE
feat: adding device health publishing from iot

### DIFF
--- a/lib/health/PitsDeviceHealth.ts
+++ b/lib/health/PitsDeviceHealth.ts
@@ -1,0 +1,115 @@
+import { ArnFormat, Duration, Stack } from "aws-cdk-lib";
+import { ITable } from "aws-cdk-lib/aws-dynamodb";
+import { Effect, IRole, PolicyDocument, PolicyStatement, Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import { CfnTopicRule } from "aws-cdk-lib/aws-iot";
+import { Construct } from "constructs";
+
+export interface PitsDeviceHealthProps {
+    readonly inputTopic?: string;
+    readonly table: ITable;
+    readonly expiresDuration?: Duration;
+}
+
+export interface IPitsDeviceHealth {
+    readonly rulesRole: IRole;
+    readonly updateLatestRuleName: string;
+    readonly updateIndexRuleName: string;
+}
+
+export class PitsDeviceHealth extends Construct implements IPitsDeviceHealth {
+    readonly rulesRole: IRole;
+    readonly updateLatestRuleName: string;
+    readonly updateIndexRuleName: string;
+
+    constructor(scope: Construct, id: string, props: PitsDeviceHealthProps) {
+        super(scope, id);
+
+        const inputTopic = props.inputTopic || 'pinthesky/events/output';
+        const republishTopic = `${inputTopic}/index`;
+        const stack = Stack.of(this);
+        this.rulesRole = new Role(this, 'Role', {
+            assumedBy: new ServicePrincipal('iot.amazonaws.com'),
+            inlinePolicies: {
+                'RepublishAndIndex': new PolicyDocument({
+                    statements: [
+                        new PolicyStatement({
+                            effect: Effect.ALLOW,
+                            actions: [
+                                'iot:Publish'
+                            ],
+                            resources: [
+                                stack.formatArn({
+                                    service: 'iot',
+                                    resource: 'topic',
+                                    arnFormat: ArnFormat.SLASH_RESOURCE_NAME,
+                                    resourceName: republishTopic
+                                })
+                            ]
+                        }),
+                        new PolicyStatement({
+                            effect: Effect.ALLOW,
+                            actions: [
+                                'dynamodb:PutItem'
+                            ],
+                            resources: [
+                                props.table.tableArn
+                            ]
+                        })
+                    ]
+                })
+            }
+        });
+
+        const tableName = "DeviceHealth";
+        const LATEST_PK = `accountid() + ":${tableName}:latest" as PK`;
+        const LATEST_SK = 'clientid() as SK';
+        const createTime = "timestamp as createTime";
+        const updateTime = "timestamp as updateTime";
+        this.updateLatestRuleName = `${id}RuleLatest`;
+        new CfnTopicRule(this, 'RuleLatest', {
+            ruleName: this.updateLatestRuleName,
+            topicRulePayload: {
+                sql: `SELECT *, ${LATEST_PK}, ${LATEST_SK}, ${createTime}, ${updateTime} FROM '${inputTopic}' WHERE name = "health_end"`,
+                ruleDisabled: false,
+                actions: [
+                    {
+                        // Republish to index this health audit trail
+                        republish: {
+                            topic: republishTopic,
+                            qos: 1,
+                            roleArn: this.rulesRole.roleArn
+                        },
+                        dynamoDBv2: {
+                            putItem: {
+                                tableName: props.table.tableName
+                            },
+                            roleArn: this.rulesRole.roleArn
+                        }
+                    }
+                ]
+            }
+        });
+
+        const INDEX_PK = `accountid() + ":${tableName}:" + thing_name as PK`;
+        const INDEX_SK = "timestamp as SK";
+        const expiresIn = `timestamp + ${props.expiresDuration || Duration.days(30).toSeconds()} as expiresIn`;
+        this.updateIndexRuleName = `${id}RuleIndex`;
+        new CfnTopicRule(this, 'RuleIndex', {
+            ruleName: this.updateIndexRuleName,
+            topicRulePayload: {
+                sql: `SELECT *, ${INDEX_PK}, ${INDEX_SK}, ${createTime}, ${updateTime}, ${expiresIn} FROM '${republishTopic}' WHERE name = "health_end"`,
+                ruleDisabled: false,
+                actions: [
+                    {
+                        dynamoDBv2: {
+                            putItem: {
+                                tableName: props.table.tableName
+                            },
+                            roleArn: this.rulesRole.roleArn
+                        }
+                    }
+                ]
+            }
+        });
+    }
+}

--- a/lib/pits-infra-stack.ts
+++ b/lib/pits-infra-stack.ts
@@ -1,4 +1,4 @@
-import { ArnFormat, Stack, StackProps } from 'aws-cdk-lib';
+import { ArnFormat, Duration, Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { Certificate } from 'aws-cdk-lib/aws-certificatemanager';
 import { HostedZone } from 'aws-cdk-lib/aws-route53';
@@ -9,6 +9,7 @@ import { SubmoduleCode } from './SubmoduleCode';
 import { PitsConsole } from './console/PitsConsole';
 import { Source } from 'aws-cdk-lib/aws-s3-deployment';
 import * as path from 'path';
+import { PitsDeviceHealth } from './health/PitsDeviceHealth';
 
 const ZONE_ID = 'Z2DL6AR506I4EE';
 const CERTIFICATE_ID = 'f2674298-1642-4284-a9a6-e90b8803ff6e';
@@ -78,6 +79,11 @@ export class PitsInfraStack extends Stack {
 
     resourceService.addNotification('Motion', {
       baseUrl: `https://${consoleDomain}`
+    });
+
+    new PitsDeviceHealth(this, 'CameraHealth', {
+      table: resourceService.table,
+      expiresDuration: Duration.days(14),
     });
 
     new PitsConsole(this, 'Console', {


### PR DESCRIPTION
- Adds two rules:
1. A rule to put the latest health for `DeviceHealth` namespace, and publishes to `index`
2. A rule to put a new entry indexes by `thing_name` with an expiry.
- Fixes #14 