### PR TITLE
fix: custom resource on role alias with empty update

### DIFF
--- a/lib/api/AwsIotAccountEndpoint.ts
+++ b/lib/api/AwsIotAccountEndpoint.ts
@@ -19,7 +19,15 @@ export class AwsIotAccountEndpoint extends Construct implements IAwsIotAccountEn
         super(scope, id);
 
         this.endpointType = props?.endpointType || 'iot:data-ats';
+        const sdkPartial = {
+            service: 'Iot',
+            action: 'describeEndpoint',
+            parameters: {
+                endpointType: this.endpointType
+            }
+        };
         const endpoint = new AwsCustomResource(this, 'Address', {
+            installLatestAwsSdk: true,
             policy: {
                 statements: [
                 new PolicyStatement({
@@ -34,13 +42,12 @@ export class AwsIotAccountEndpoint extends Construct implements IAwsIotAccountEn
                 ]
             },
             onCreate: {
+                ...sdkPartial,
                 physicalResourceId: PhysicalResourceId.of('iot' + id),
-                service: 'Iot',
-                action: 'describeEndpoint',
-                parameters: {
-                    endpointType: this.endpointType
-                }
             },
+            onUpdate: {
+                ...sdkPartial,
+            }
         });
 
         this.endpointAddress = endpoint.getResponseField('endpointAddress');

--- a/lib/api/PitsResourceService.ts
+++ b/lib/api/PitsResourceService.ts
@@ -329,7 +329,7 @@ export class PitsResourceService extends Construct implements IPitsResourceServi
     addNotification(id: string, props: PitsResourceServiceNotificationProps): void {
         const indexFunction = new Function(this, `${id}IndexFunction`, {
             code: Code.fromAsset(path.join(__dirname, 'handlers', 'index_conversion')),
-            runtime: Runtime.PYTHON_3_9,
+            runtime: Runtime.PYTHON_3_12,
             handler: 'index.handler',
             environment: {
                 'TABLE_NAME': this.table.tableName,
@@ -357,7 +357,7 @@ export class PitsResourceService extends Construct implements IPitsResourceServi
 
         const notificationFunction = new Function(this, `${id}AlertFunction`, {
             code: Code.fromAsset(path.join(__dirname, 'handlers', 'publish_motion')),
-            runtime: Runtime.PYTHON_3_9,
+            runtime: Runtime.PYTHON_3_12,
             handler: 'index.handler',
             environment: {
                 'TABLE_NAME': this.table.tableName,

--- a/lib/device/PitsRoleAlias.ts
+++ b/lib/device/PitsRoleAlias.ts
@@ -22,7 +22,8 @@ export class PitsRoleAlias extends Construct implements IPitsRoleAlias {
 
         let stack = Stack.of(scope);
         this.roleAliasName = props.roleAliasName || 'PinTheSkyRoleAlias';
-        const roleAlias = new AwsCustomResource(this, 'RoleAlias', {
+        new AwsCustomResource(this, 'RoleAlias', {
+            installLatestAwsSdk: true,
             policy: {
                 statements: [
                 new PolicyStatement({

--- a/lib/device/PitsRoleAlias.ts
+++ b/lib/device/PitsRoleAlias.ts
@@ -1,4 +1,4 @@
-import { Stack } from "aws-cdk-lib";
+import { ArnFormat, Stack } from "aws-cdk-lib";
 import { Effect, IRole, PolicyStatement } from "aws-cdk-lib/aws-iam";
 import { AwsCustomResource, PhysicalResourceId } from "aws-cdk-lib/custom-resources";
 import { Construct } from "constructs";
@@ -69,6 +69,11 @@ export class PitsRoleAlias extends Construct implements IPitsRoleAlias {
             }
         });
 
-        this.roleAliasArn = roleAlias.getResponseField('roleAliasArn');
+        this.roleAliasArn = stack.formatArn({
+            service: 'iot',
+            resource: 'rolealias',
+            arnFormat: ArnFormat.SLASH_RESOURCE_NAME,
+            resourceName: this.roleAliasName
+        });
     }
 }

--- a/lib/device/PitsThingPolicy.ts
+++ b/lib/device/PitsThingPolicy.ts
@@ -118,6 +118,7 @@ export class PitsThingPolicy extends Construct implements IPitsThingPolicy {
         };
 
         new AwsCustomResource(this, 'ThingPolicy', {
+            installLatestAwsSdk: true,
             policy: {
                 statements: [
                 new PolicyStatement({

--- a/lib/health/PitsDeviceHealth.ts
+++ b/lib/health/PitsDeviceHealth.ts
@@ -172,7 +172,7 @@ export class PitsDeviceHealth extends Construct implements IPitsDeviceHealth {
 
         const handler = new Function(this, `${id}Function`, {
             handler: 'index.handler',
-            runtime: Runtime.PYTHON_3_9,
+            runtime: Runtime.PYTHON_3_12,
             code: Code.fromAsset(path.join(__dirname, 'handlers', 'check_health')),
             memorySize: 512,
             timeout: Duration.minutes(1),


### PR DESCRIPTION
The role alias *function* is being updated and the update does not return a value, therefore causing the deployment to fail on existing stacks. This fix simply returns the role alias ARN which is a deterministic value.